### PR TITLE
Wait for standalone-openwhisk jar to be running

### DIFF
--- a/test/scripts/dev.test.js
+++ b/test/scripts/dev.test.js
@@ -56,6 +56,8 @@ describe('dev command is exported', () => {
 // isLocal -> no whisk jar, no network, should fail
 // isLocal - should backup .env file
 // isLocal -> should write devConfig to .env
+// isLocal -> should wait for whisk jar startup
+// isLocal -> should fail if whisk jar startup timeouts
 
 // should BuildActions with devConfig
 // should DeployActions with devConfig


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace the arbitrary timer of 7000ms with a proper wait for openwhisk running.

This is done by simply polling on `api/v1` enpoint + timeout after 20s

The motivation behind this is:
1. 7000ms now is not enough on my machine, somehow fail 1/2 times
2. could be solved by choosing a high waiting time but would slow down the command considerably

<!--- Describe your changes in detail -->

## How Has This Been Tested?

Manually tested, did not add unit tests yet as waiting for first tests on rundev command.
Can add some later if this ok (put 2 comments for 2 future unit tests)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
